### PR TITLE
docs: update the readme to latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,11 @@
-# Binance Chain Java SDK
+# BNB Beacon Chain Java SDK
 
-The Binance Chain Java SDK works as a lightweight Java library for interacting with the [Binance Chain](https://docs.bnbchain.org/docs/beaconchain/develop/api-reference/dex-api/paths). It provides a complete API coverage, and supports synchronous and asynchronous requests.  It includes the following core components:
+The BNB Beacon Chain Java SDK works as a lightweight Java library for interacting with the [BNB Beacon Chain](https://docs.bnbchain.org/docs/beaconchain/develop/api-reference/dex-api/paths). It provides a complete API coverage, and supports synchronous and asynchronous requests.  It includes the following core components:
 
 * **[crypto](https://github.com/bnb-chain/java-sdk/blob/master/src/main/java/com/binance/dex/api/client/encoding/Crypto.java)** - core cryptographic functions.
 * **[amino encoding](https://github.com/bnb-chain/java-sdk/blob/master/src/main/java/com/binance/dex/api/client/encoding)** - [amino](https://docs.bnbchain.org/docs/beaconchain/learn/encoding/encoding/#amino) (protobuf-like) encoding and decoding of transactions.
-* **[client](https://github.com/bnb-chain/java-sdk/tree/master/src/main/java/com/binance/dex/api/client/impl)** - implementations of API rest client, supporting synchronous and asynchronous access to Binance Chain's REST APIs.
+* **[client](https://github.com/bnb-chain/java-sdk/tree/master/src/main/java/com/binance/dex/api/client/impl)** - implementations of API rest client, supporting synchronous and asynchronous access to BNB Beacon Chain's REST APIs.
 * **[wallet](https://github.com/bnb-chain/java-sdk/blob/master/src/main/java/com/binance/dex/api/client/Wallet.java)** - management of accounts, including seed and encrypted mnemonic generation.
-
-## Disclaimer
-**This branch is under active development, all subject to potential future change without notification and not ready for production use. The code and security audit have not been fully completed and not ready for any bug bounty.**
 
 # How to get
 
@@ -40,12 +37,12 @@ More details please refer to https://github.com/xolstice/protobuf-maven-plugin
 
 # API
 
-For examples, please check the [wiki](https://github.com/bnb-chain/java-sdk/wiki).
+For examples, please check the [wiki](https://github.com/bnb-chain/java-sdk/wiki/API).
 
 # Testing
 
-All new code changes should be covered with unit tests. You can see the existing test cases here: https://github.com/bnb-chain/java-sdk/tree/master/src/test/java/com/binance/dex/api/client/encoding 
+All new code changes should be covered with unit tests. You can see the existing test cases [here](https://github.com/bnb-chain/java-sdk/tree/master/src/test/java/com/binance/dex/api/client/encoding). 
 
 # Contributing
 
-Contributions to the Binance Chain Java SDK are welcome. Please ensure that you have tested the changes with a local client and have added unit test coverage for your code.
+Contributions to the BNB Beacon Chain Java SDK are welcome. Please ensure that you have tested the changes with a local client and have added unit test coverage for your code.


### PR DESCRIPTION
### Description
Binance Dex is rename to BNB Beacon chain, this PR change the related part in the readme.

### Rationale
1. Remove Binance word in the readme.
2. Remove Disclaimer part.
3. Fix the wiki link.


### Example
No impact to user

### Changes
TODO: change the binance path to bnb-chain?
