### PR TITLE
fix: fix side vote addr not parsed issue

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2018-2019 Binance
+   Copyright 2018-2019 All BNB Chain Developers
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2018-2019 All BNB Chain Developers
+   Copyright 2018-2019 Binance
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/main/java/com/binance/dex/api/client/BinanceDexApiClientGenerator.java
+++ b/src/main/java/com/binance/dex/api/client/BinanceDexApiClientGenerator.java
@@ -18,14 +18,14 @@ import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.util.concurrent.TimeUnit;
 
-public class BNBDexApiClientGenerator {
+public class BinanceDexApiClientGenerator {
     private static final Converter.Factory converterFactory =
             JacksonConverterFactory.create(new ObjectMapper().registerModule(new JodaModule()));
 
     @SuppressWarnings("unchecked")
-    private static final Converter<ResponseBody, BNBDexApiError> errorBodyConverter =
-            (Converter<ResponseBody, BNBDexApiError>) converterFactory.responseBodyConverter(
-                    BNBDexApiError.class, new Annotation[0], null);
+    private static final Converter<ResponseBody, BinanceDexApiError> errorBodyConverter =
+            (Converter<ResponseBody, BinanceDexApiError>) converterFactory.responseBodyConverter(
+                    BinanceDexApiError.class, new Annotation[0], null);
 
     private static OkHttpClient sharedClient;
     static {
@@ -78,21 +78,21 @@ public class BNBDexApiClientGenerator {
                 return response.body();
             } else {
                 try {
-                    BNBDexApiError apiError = getBNBApiError(response);
-                    throw new BNBDexApiException(apiError);
+                    BinanceDexApiError apiError = getBinanceApiError(response);
+                    throw new BinanceDexApiException(apiError);
                 } catch (IOException e) {
-                    throw new BNBDexApiException(response.code(), response.toString());
+                    throw new BinanceDexApiException(response.code(), response.toString());
                 }
             }
         } catch (IOException e) {
-            throw new BNBDexApiException(e);
+            throw new BinanceDexApiException(e);
         }
     }
 
     /**
      * Extracts and converts the response error body into an object.
      */
-    public static BNBDexApiError getBNBApiError(Response<?> response) throws IOException {
+    public static BinanceDexApiError getBinanceApiError(Response<?> response) throws IOException {
         return errorBodyConverter.convert(response.errorBody());
     }
 

--- a/src/main/java/com/binance/dex/api/client/BinanceDexApiError.java
+++ b/src/main/java/com/binance/dex/api/client/BinanceDexApiError.java
@@ -5,7 +5,7 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class BNBDexApiError {
+public class BinanceDexApiError {
     private int code;
     private String message;
 

--- a/src/main/java/com/binance/dex/api/client/BinanceDexApiException.java
+++ b/src/main/java/com/binance/dex/api/client/BinanceDexApiException.java
@@ -1,30 +1,30 @@
 package com.binance.dex.api.client;
 
 
-public class BNBDexApiException extends RuntimeException {
+public class BinanceDexApiException extends RuntimeException {
     private static final long serialVersionUID = 3788669840036201041L;
-    private BNBDexApiError error;
+    private BinanceDexApiError error;
 
-    public BNBDexApiException(BNBDexApiError error) {
+    public BinanceDexApiException(BinanceDexApiError error) {
         this.error = error;
     }
 
-    public BNBDexApiException(Throwable cause) {
+    public BinanceDexApiException(Throwable cause) {
         super(cause);
     }
 
-    public BNBDexApiException(int code,String message){
-        BNBDexApiError apiError = new BNBDexApiError();
+    public BinanceDexApiException(int code,String message){
+        BinanceDexApiError apiError = new BinanceDexApiError();
         apiError.setCode(code);
         apiError.setMessage(message);
         this.error = apiError;
     }
 
-    public BNBDexApiException(String message, Throwable cause) {
+    public BinanceDexApiException(String message, Throwable cause) {
         super(message, cause);
     }
 
-    public BNBDexApiError getError() {
+    public BinanceDexApiError getError() {
         return error;
     }
 

--- a/src/main/java/com/binance/dex/api/client/BinanceDexConstants.java
+++ b/src/main/java/com/binance/dex/api/client/BinanceDexConstants.java
@@ -7,14 +7,14 @@ public class BinanceDexConstants {
     /**
      * Identifier of this client.
      */
-    public static final long BNB_DEX_API_CLIENT_JAVA_SOURCE = 0L;
+    public static final long BINANCE_DEX_API_CLIENT_JAVA_SOURCE = 0L;
 
     /**
      * Default ToStringStyle used by toString methods.
      * Override this to change the output format of the overridden toString methods.
      * - Example ToStringStyle.JSON_STYLE
      */
-    public static final ToStringStyle BNB_DEX_TO_STRING_STYLE = ToStringStyle.SHORT_PREFIX_STYLE;
+    public static final ToStringStyle BINANCE_DEX_TO_STRING_STYLE = ToStringStyle.SHORT_PREFIX_STYLE;
 
     /**
      * HTTP Header to be used for API-KEY authentication.

--- a/src/main/java/com/binance/dex/api/client/BinanceDexEnvironment.java
+++ b/src/main/java/com/binance/dex/api/client/BinanceDexEnvironment.java
@@ -3,8 +3,8 @@ package com.binance.dex.api.client;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
-public class BNBDexEnvironment {
-    public static final BNBDexEnvironment PROD = new BNBDexEnvironment(
+public class BinanceDexEnvironment {
+    public static final BinanceDexEnvironment PROD = new BinanceDexEnvironment(
             "https://dex.binance.org",
             "https://api.binance.org/bc/",
             "wss://dex.binance.org/api",
@@ -13,7 +13,7 @@ public class BNBDexEnvironment {
             "bnb",
             "bva"
     );
-    public static final BNBDexEnvironment TEST_NET = new BNBDexEnvironment(
+    public static final BinanceDexEnvironment TEST_NET = new BinanceDexEnvironment(
             "https://testnet-dex.binance.org",
             "https://testnet-api.binance.org/bc/",
             "wss://testnet-dex.binance.org/api",
@@ -23,7 +23,7 @@ public class BNBDexEnvironment {
             "bva"
     );
 
-    public static final BNBDexEnvironment LOCAL_NET = new BNBDexEnvironment(
+    public static final BinanceDexEnvironment LOCAL_NET = new BinanceDexEnvironment(
             "https://testnet-dex.binance.org",
             "https://testnet-api.binance.org/bc/",
             "wss://testnet-dex.binance.org/api",

--- a/src/main/java/com/binance/dex/api/client/BinanceDexNodeApi.java
+++ b/src/main/java/com/binance/dex/api/client/BinanceDexNodeApi.java
@@ -6,7 +6,7 @@ import retrofit2.Call;
 import retrofit2.http.GET;
 import retrofit2.http.Query;
 
-public interface BNBDexNodeApi {
+public interface BinanceDexNodeApi {
 
     @GET("/abci_query")
     Call<JsonRpcResponse<AccountResult>> getAccount(@Query("path") String pathWithAddress);

--- a/src/main/java/com/binance/dex/api/client/BinanceTransactionApi.java
+++ b/src/main/java/com/binance/dex/api/client/BinanceTransactionApi.java
@@ -6,7 +6,7 @@ import retrofit2.http.GET;
 import retrofit2.http.Path;
 import retrofit2.http.Query;
 
-public interface BNBTransactionApi {
+public interface BinanceTransactionApi {
     @GET("api/v1/txs")
     Call<TransactionPageV2> getTransactions(@Query(value = "startTime") Long startTime,
                                             @Query(value = "endTime") Long endTime,

--- a/src/main/java/com/binance/dex/api/client/TransactionConverter.java
+++ b/src/main/java/com/binance/dex/api/client/TransactionConverter.java
@@ -1423,8 +1423,12 @@ public class TransactionConverter {
             editSideChainValidator.setSideFeeAddr("0x" + Hex.toHexString(message.getSideFeeAddr()));
         }
 
+        if (message.getSideConsAddr() != null) {
+            editSideChainValidator.setSideConsAddr("0x" + Hex.toHexString(message.getSideConsAddr()));
+        }
+
         if (message.getSideVoteAddr() != null) {
-            editSideChainValidator.setSideVoteAddr("0x" + Hex.toHexString(message.getSideVoteAddr()));
+            editSideChainValidator.setSideVoteAddr("0x"+ Hex.toHexString(message.getSideVoteAddr()));
         }
 
         Transaction transaction = new Transaction();

--- a/src/main/java/com/binance/dex/api/client/domain/stake/sidechain/EditSideChainValidatorWithVoteAddr.java
+++ b/src/main/java/com/binance/dex/api/client/domain/stake/sidechain/EditSideChainValidatorWithVoteAddr.java
@@ -14,6 +14,8 @@ public class EditSideChainValidatorWithVoteAddr {
 
     private String sideFeeAddr;
 
+    private String sideConsAddr;
+
     private String sideVoteAddr;
 
     public EditSideChainValidatorWithVoteAddr() {
@@ -59,6 +61,14 @@ public class EditSideChainValidatorWithVoteAddr {
         this.sideFeeAddr = sideFeeAddr;
     }
 
+    public String getSideConsAddr() {
+        return sideConsAddr;
+    }
+
+    public void setSideConsAddr(String sideConsAddr) {
+        this.sideConsAddr = sideConsAddr;
+    }
+
     public String getSideVoteAddr() {
         return sideVoteAddr;
     }
@@ -69,12 +79,13 @@ public class EditSideChainValidatorWithVoteAddr {
 
     @Override
     public String toString() {
-        return "EditSideChainValidator{" +
+        return "EditSideChainValidatorWithVoteAddr{" +
                 "description=" + description + "\n" +
                 ", validatorAddress='" + validatorAddress + '\'' + "\n" +
                 ", commissionRate=" + commissionRate + "\n" +
                 ", sideChainId='" + sideChainId + '\'' + "\n" +
                 ", sideFeeAddr='" + sideFeeAddr + '\'' + "\n" +
+                ", sideConsAddr='" + sideConsAddr + '\'' + "\n" +
                 ", sideVoteAddr='" + sideVoteAddr + '\'' + "\n" +
                 '}';
     }

--- a/src/main/java/com/binance/dex/api/client/encoding/message/sidechain/transaction/EditSideChainValidatorWithVoteAddrMessage.java
+++ b/src/main/java/com/binance/dex/api/client/encoding/message/sidechain/transaction/EditSideChainValidatorWithVoteAddrMessage.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 
 /**
  * @author Fitz.Lu
@@ -38,6 +39,9 @@ public class EditSideChainValidatorWithVoteAddrMessage implements BinanceDexTran
     @JsonProperty(value = "side_fee_addr")
     private byte[] sideFeeAddr;
 
+    @JsonProperty(value = "side_cons_addr")
+    private byte[] sideConsAddr;
+
     @JsonProperty(value = "side_vote_addr")
     private byte[] sideVoteAddr;
 
@@ -60,7 +64,10 @@ public class EditSideChainValidatorWithVoteAddrMessage implements BinanceDexTran
                 sideFeeAddr = ((byte[]) value);
                 break;
             case 6:
-                sideVoteAddr = ((byte[]) value);
+                sideConsAddr = ((byte[]) value);
+                break;
+            case 7:
+                setSideVoteAddr((byte[]) value);
                 break;
             default:
                 break;
@@ -110,11 +117,22 @@ public class EditSideChainValidatorWithVoteAddrMessage implements BinanceDexTran
         this.sideFeeAddr = sideFeeAddr;
     }
 
+    public byte[] getSideConsAddr() {
+        return sideConsAddr;
+    }
+
+    public void setSideConsAddr(byte[] sideConsAddr) {
+        this.sideConsAddr = sideConsAddr;
+    }
+
     public byte[] getSideVoteAddr() {
         return sideVoteAddr;
     }
 
     public void setSideVoteAddr(byte[] sideVoteAddr) {
+        if (sideVoteAddr != null && sideVoteAddr.length > 48) {
+            sideVoteAddr = Arrays.copyOfRange(sideVoteAddr, 0, 48);
+        }
         this.sideVoteAddr = sideVoteAddr;
     }
 
@@ -136,6 +154,7 @@ public class EditSideChainValidatorWithVoteAddrMessage implements BinanceDexTran
                 .addField(Dec.class, commissionRate, commissionRate == null || commissionRate.isDefaultOrEmpty())
                 .addField(String.class, sideChainId, StringUtils.isEmpty(sideChainId))
                 .addField(byte[].class, sideFeeAddr, sideFeeAddr == null || sideFeeAddr.length == 0)
+                .addField(byte[].class, sideConsAddr, sideConsAddr == null || sideConsAddr.length == 0)
                 .addField(byte[].class, sideVoteAddr, sideVoteAddr == null || sideVoteAddr.length == 0)
                 .build();
     }

--- a/src/test/java/com/binance/dex/api/client/encoding/AminoTest.java
+++ b/src/test/java/com/binance/dex/api/client/encoding/AminoTest.java
@@ -305,17 +305,18 @@ public class AminoTest {
         //set new rate if needed
         editSideChainValidator.setCommissionRate(1L);
 
-        //set new fee address if needed
-        editSideChainValidator.setSideFeeAddr("0xd1B22dCC24C55f4d728E7aaA5c9b5a22e1512C08");
-
         editSideChainValidator.setSideChainId("bsc");
 
-        editSideChainValidator.setSideVoteAddr("0x11FfBAC7fA17f5c9084a15C8f0f15dAe845A5712");
+        //set new fee address if needed
+        editSideChainValidator.setSideFeeAddr("0xd1B22dCC24C55f4d728E7aaA5c9b5a22e1512C08");
+        editSideChainValidator.setSideConsAddr("0xd1B22dCC24C55f4d728E7aaA5c9b5a22e1512C99");
+        editSideChainValidator.setSideVoteAddr("0xa96c45e0043e98a4271d84265a0a5177795c61aa188c42a94ecc4b2e54073613a46f49ff1c03e29d4a744fd56589e3a0");
 
         byte[] msg = amino.encode(convert(editSideChainValidator), MessageType.EditSideChainValidatorWithVoteAddr.getTypePrefixBytes(), false);
 
         Transaction tx = transactionConverter.convert(msg);
         Assert.assertNotNull(tx.getRealTx());
+        Assert.assertEquals("0xa96c45e0043e98a4271d84265a0a5177795c61aa188c42a94ecc4b2e54073613a46f49ff1c03e29d4a744fd56589e3a0", ((EditSideChainValidatorWithVoteAddr)tx.getRealTx()).getSideVoteAddr());
     }
 
     EditSideChainValidatorMessage convert(EditSideChainValidator editSideChainValidator) {
@@ -453,6 +454,7 @@ public class AminoTest {
         message.setCommissionRate(Dec.newInstance(editSideChainValidator.getCommissionRate()));
         message.setSideChainId(editSideChainValidator.getSideChainId());
         message.setSideFeeAddr(decodeHexAddress(editSideChainValidator.getSideFeeAddr()));
+        message.setSideConsAddr(decodeHexAddress(editSideChainValidator.getSideConsAddr()));
         message.setSideVoteAddr(decodeHexAddress(editSideChainValidator.getSideVoteAddr()));
 
         return message;

--- a/src/test/java/com/binance/dex/api/client/examples/NodeClientExample.java
+++ b/src/test/java/com/binance/dex/api/client/examples/NodeClientExample.java
@@ -27,7 +27,7 @@ public class NodeClientExample {
 
     @Before
     public void setup() {
-        binanceDexNodeApi = BinanceDexApiClientFactory.newInstance().newNodeRpcClient(BinanceDexEnvironment.LOCAL_NET.getNodeUrl(), BinanceDexEnvironment.LOCAL_NET.getHrp(), BinanceDexEnvironment.LOCAL_NET.getValHrp());
+        binanceDexNodeApi = BinanceDexApiClientFactory.newInstance().newNodeRpcClient(BinanceDexEnvironment.PROD.getNodeUrl(), BinanceDexEnvironment.PROD.getHrp(), BinanceDexEnvironment.PROD.getValHrp());
     }
 
     @Test
@@ -293,14 +293,14 @@ public class NodeClientExample {
 
     @Test
     public void testCreateSidechainValidatorWithVoteAddr() {
-        Transaction transaction = binanceDexNodeApi.getTransaction("0B660182B6E571A2BF9644624EA75890FC5C87F45759B4B0CC74BAA63B61501C");
+        Transaction transaction = binanceDexNodeApi.getTransaction("7A6A818048DBE4330BC72DD169F684F2E51E8780185A140E1F1B0AF5414EA48A");
         Assert.assertNotNull(transaction);
         Assert.assertEquals(transaction.getTxType(), TxType.CREATE_SIDECHAIN_VALIDATOR_WITH_VOTE_ADDR);
     }
 
     @Test
     public void testEditSidechainValidatorWithVoteAddr() {
-        Transaction transaction = binanceDexNodeApi.getTransaction("037A67C45ADFEE6F978D1B02EEB18BAD6EE427C3BA55674B3F2C421E42E7D1DB");
+        Transaction transaction = binanceDexNodeApi.getTransaction("30A5699E193929FB04F1D6C151303ABAA4E9D51CC1F718A9E8BD4E086DFDE305");
         Assert.assertNotNull(transaction);
         Assert.assertEquals(transaction.getTxType(), TxType.EDIT_SIDECHAIN_VALIDATOR_WITH_VOTE_ADDR);
     }


### PR DESCRIPTION
This pr fixes the issue of parsing vote address from `EditSideChainValidatorWithVoteAddr` transaction.

Be noted, #144 is reverted due to lots of compile issues.